### PR TITLE
Typography Chakra

### DIFF
--- a/src/pages/User/Login.js
+++ b/src/pages/User/Login.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { useDispatch } from 'react-redux';
-import { Box, Button, Input } from '@chakra-ui/react';
+import { Box, Button, Heading, Input } from '@chakra-ui/react';
 import { login } from '../../data/actions/auth';
 
 function Login() {
@@ -25,7 +25,7 @@ function Login() {
 
   return (
     <div>
-      <h1>Login Page</h1>
+      <Heading as="h1">Login Page</Heading>
       <Box w="50%">
         <form onSubmit={handleClick}>
           <div>

--- a/src/shared/App.js
+++ b/src/shared/App.js
@@ -11,6 +11,7 @@ import dashboardTheme from '../themes/dashboard';
 
 import ProtectedRoute from '../components/ProtectedRoute/ProtectedRoute';
 import { currentUser } from '../data/actions/auth';
+import ChakraExpoDashboard from '../themes/dashboard/ChakraExpoDashboard';
 
 // const GET_TEAMS = gql`
 //   query {
@@ -48,6 +49,11 @@ function App() {
             </Route>
             <Route exact path="/register">
               <Register />
+            </Route>
+            <Route exact path="/chakraExpo">
+              <ChakraProvider theme={dashboardTheme}>
+                <ChakraExpoDashboard />
+              </ChakraProvider>
             </Route>
             <ProtectedRoute path="/">
               <Grid templateColumns="280px 1fr" h="100vh">

--- a/src/themes/dashboard/ChakraExpoDashboard.js
+++ b/src/themes/dashboard/ChakraExpoDashboard.js
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { Box, Button, Grid, Heading, Input } from '@chakra-ui/react';
+import { Box, Button, Heading, Input, Stack } from '@chakra-ui/react';
 
 /* Temporary code for easily seeing Chakra stuff, will be removed later */
 const ChakraExpoDashboard = () => {
@@ -8,10 +8,12 @@ const ChakraExpoDashboard = () => {
 
   return (
     <Box p="36px">
-      <Grid autoFlow="row" gap="16px" maxW="50%" border="1px solid black" p="8px">
-        <Heading as="h1" size="h1">
-          Heading 1
-        </Heading>
+      <Stack direction="column" spacing="16px" maxW="50%" border="1px solid black" p="8px">
+        <Stack>
+          <Heading as="h1" size="h1">
+            Heading 1
+          </Heading>
+        </Stack>
         <Heading as="h2" size="h2">
           Heading 2
         </Heading>
@@ -29,7 +31,7 @@ const ChakraExpoDashboard = () => {
         <Button type="button" role="button">
           Button
         </Button>
-      </Grid>
+      </Stack>
     </Box>
   );
 };

--- a/src/themes/dashboard/ChakraExpoDashboard.js
+++ b/src/themes/dashboard/ChakraExpoDashboard.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+
+import { Box, Button, Grid, Heading, Input } from '@chakra-ui/react';
+
+/* Temporary code for easily seeing Chakra stuff, will be removed later */
+const ChakraExpoDashboard = () => {
+  const [value, setValue] = useState('');
+
+  return (
+    <Box p="36px">
+      <Grid autoFlow="row" gap="16px" maxW="50%" border="1px solid black" p="8px">
+        <Heading as="h1" size="h1">
+          Heading 1
+        </Heading>
+        <Heading as="h2" size="h2">
+          Heading 2
+        </Heading>
+        <Heading as="h3" size="h3">
+          Heading 3
+        </Heading>
+        <Heading as="h4" size="h4">
+          Heading 4
+        </Heading>
+        <Heading as="h2" size="subtitle">
+          Subtitle
+        </Heading>
+        <div>Here is some body text</div>
+        <Input type="text" name="text" placeholder="Input..." value={value} onChange={e => setValue(e.target.value)} />
+        <Button type="button" role="button">
+          Button
+        </Button>
+      </Grid>
+    </Box>
+  );
+};
+
+export default ChakraExpoDashboard;

--- a/src/themes/dashboard/components/Button.js
+++ b/src/themes/dashboard/components/Button.js
@@ -1,9 +1,6 @@
 const Button = {
   // The styles all buttons have in common
-  baseStyle: {
-    fontWeight: 'bold',
-    textTransform: 'capitalize',
-  },
+  baseStyle: {},
   // We can override sizes here, if we want to
   sizes: {},
   // The default variant is solid, so we must override colors here
@@ -19,9 +16,7 @@ const Button = {
     },
   },
   // The default button prop values
-  defaultProps: {
-    size: 'lg',
-  },
+  defaultProps: {},
 };
 
 export default Button;

--- a/src/themes/dashboard/components/Heading.js
+++ b/src/themes/dashboard/components/Heading.js
@@ -1,0 +1,47 @@
+/* 
+  Useful references:
+  * https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/heading.ts 
+  * https://chakra-ui.com/docs/theming/theme#typography
+  * https://www.figma.com/file/s6xLJftM99Xto7FW9AAtGU/Building-Up---Dashboard?node-id=437%3A301
+*/
+
+const Heading = {
+  sizes: {
+    h1: {
+      // 4xl = 2.25 rem = 36px
+      // Same as the default "xl" heading size
+      fontSize: ['3xl', null, '4xl'],
+      lineHeight: [1.33, null, 1.2],
+    },
+    h2: {
+      // 3xl = 1.75 rem = 30px
+      // Same as the default "lg" heading size except fontWeight is semibold
+      fontSize: ['2xl', null, '3xl'],
+      lineHeight: [1.33, null, 1.2],
+      fontWeight: 'semibold',
+    },
+    h3: {
+      // 2xl = 24px
+      fontSize: '2xl',
+      lineHeight: 1.2,
+      fontWeight: 'semibold',
+    },
+    h4: {
+      // xl = 20px
+      fontSize: 'xl',
+      lineHeight: 1.2,
+      fontWeight: 'semibold',
+    },
+    subtitle: {
+      fontSize: 'md',
+      lineHeight: 1.2,
+      fontWeight: 'semibold',
+      textTransform: 'uppercase',
+    },
+  },
+  defaultProps: {
+    size: 'h1',
+  },
+};
+
+export default Heading;

--- a/src/themes/dashboard/components/Input.js
+++ b/src/themes/dashboard/components/Input.js
@@ -15,7 +15,6 @@ const Input = {
     md: {
       field: {
         height: '48px',
-        borderRadius: '4px',
       },
     },
   },

--- a/src/themes/dashboard/components/Input.js
+++ b/src/themes/dashboard/components/Input.js
@@ -1,3 +1,9 @@
+/* 
+  Useful references:
+  * https://chakra-ui.com/docs/form/input
+  * https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/input.ts
+*/
+
 const Input = {
   parts: ['field'],
   baseStyle: {
@@ -10,6 +16,13 @@ const Input = {
       field: {
         height: '48px',
         borderRadius: '4px',
+      },
+    },
+  },
+  variants: {
+    outline: {
+      field: {
+        borderColor: 'rgba(0,0,0,0.2)',
       },
     },
   },

--- a/src/themes/dashboard/index.js
+++ b/src/themes/dashboard/index.js
@@ -1,11 +1,24 @@
 import { extendTheme } from '@chakra-ui/react';
 import Button from './components/Button';
 import Input from './components/Input';
+import Heading from './components/Heading';
 
 const dashboardTheme = extendTheme({
+  styles: {
+    global: {
+      body: {
+        color: 'black',
+      },
+    },
+  },
+
+  fonts: {
+    body: 'Jost, system-ui, sans-serif',
+    heading: 'Jost, system-ui, sans-serif',
+  },
   colors: {
     brand: {
-      50: '#fbebeb',
+      50: '#f5d5d5',
       100: '#edc1c1',
       200: '#e39898',
       300: '#da6f6e',
@@ -25,6 +38,7 @@ const dashboardTheme = extendTheme({
   components: {
     Button,
     Input,
+    Heading,
   },
 });
 


### PR DESCRIPTION
@tawnyzhao I decided to implement this typography stuff so you can do some more interesting work (also we'll be needing this for all devs ASAP)

## Description

https://www.notion.so/uwblueprintexecs/Building-Up-be1b30c321554bffba37a64c6cdc1ec6?p=4d7b3c24b576487a8f4f2fdde2d320c1

Adds all typography-related stuff from the design system, including the headings and using `Jost` as the font. I followed the design in Figma pretty closely, the only change I made is I used the font sizes from Chakra rather than the ones we had in Figma. I think the only actual difference is `h2` in Chakra is 30px, while in Figma it was 28px

## Approach

I created "sizes" for the Chakra `Heading` component like h1, h2, etc. 

I prefer this over globally styling h1, h2, for the following reasons:
* Allows us to use a heading that is semantically `h1` but "size" `h3` (or other such combinations). This might be needed?
* Applying styles to only our Chakra components seems better to keep all styles isolated and make sure we explicitly use our Chakra components like `Heading as='h1' size='h1'` rather than `h1`

So we can write this to make a heading with our styles:
```
<Heading as="h1" size="h2" >...</Heading>
```

But this does NOT get any Chakra styles

```
<h1>...</h1>
```

Also created a quick page demoing all the components we've created, this should be useful while developing. It's under the path `/chakraExpo`

## Testing

Go to path `/chakraExpo`. Verify the design with the Figma design

## Screenshots

![image](https://user-images.githubusercontent.com/26701004/108098123-fe3c6e80-7050-11eb-8aa0-717ce4e6d91e.png)

