### PR TITLE
Email Service for Inviting Users to Team

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,5 +27,3 @@ yarn-error.log*
 terraform/terraform.tfstate
 terraform.tfstate.backup
 terraform/.terraform
-
-.env

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,5 @@ yarn-error.log*
 terraform/terraform.tfstate
 terraform.tfstate.backup
 terraform/.terraform
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "@emotion/styled": "^11.0.0",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",
-        "@sendgrid/mail": "^7.4.2",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.5.0",
         "@testing-library/user-event": "^7.2.1",
@@ -2485,41 +2484,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
-    "node_modules/@sendgrid/client": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.4.2.tgz",
-      "integrity": "sha512-bu8lLbRD+OV7YsYNemEy8DRoxs8/8u325EXNlQ3VaqhcpbM0eSvdL5e5Wa7VZpbczcNCJmf/sr/uqFmwcO5S+A==",
-      "dependencies": {
-        "@sendgrid/helpers": "^7.4.2",
-        "axios": "^0.21.1"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >=10.*"
-      }
-    },
-    "node_modules/@sendgrid/helpers": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.4.2.tgz",
-      "integrity": "sha512-b/IyBwT4zrOfXA0ISvWZsnhYz+5uAO20n68J8n/6qe5P1E2p0L7kWNTN5LYu0S7snJPUlbEa6FpfrSKzEcP9JA==",
-      "dependencies": {
-        "deepmerge": "^4.2.2"
-      },
-      "engines": {
-        "node": ">= 6.0.0"
-      }
-    },
-    "node_modules/@sendgrid/mail": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.4.2.tgz",
-      "integrity": "sha512-hvIOnm8c3zVyDnJcyBuAeujmpKX56N3D/LpiZrFuLHjAz4iEHrmL2sJ3iU9O6hxcb07gd1CES+z9Fg7FBT26uQ==",
-      "dependencies": {
-        "@sendgrid/client": "^7.4.2",
-        "@sendgrid/helpers": "^7.4.2"
-      },
-      "engines": {
-        "node": "6.* || 8.* || >=10.*"
-      }
-    },
     "node_modules/@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -3959,14 +3923,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
-    },
-    "node_modules/axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "dependencies": {
-        "follow-redirects": "^1.10.0"
-      }
     },
     "node_modules/axobject-query": {
       "version": "2.2.0",
@@ -6142,14 +6098,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "node_modules/deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/default-gateway": {
       "version": "4.2.0",
@@ -21056,32 +21004,6 @@
         }
       }
     },
-    "@sendgrid/client": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.4.2.tgz",
-      "integrity": "sha512-bu8lLbRD+OV7YsYNemEy8DRoxs8/8u325EXNlQ3VaqhcpbM0eSvdL5e5Wa7VZpbczcNCJmf/sr/uqFmwcO5S+A==",
-      "requires": {
-        "@sendgrid/helpers": "^7.4.2",
-        "axios": "^0.21.1"
-      }
-    },
-    "@sendgrid/helpers": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.4.2.tgz",
-      "integrity": "sha512-b/IyBwT4zrOfXA0ISvWZsnhYz+5uAO20n68J8n/6qe5P1E2p0L7kWNTN5LYu0S7snJPUlbEa6FpfrSKzEcP9JA==",
-      "requires": {
-        "deepmerge": "^4.2.2"
-      }
-    },
-    "@sendgrid/mail": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.4.2.tgz",
-      "integrity": "sha512-hvIOnm8c3zVyDnJcyBuAeujmpKX56N3D/LpiZrFuLHjAz4iEHrmL2sJ3iU9O6hxcb07gd1CES+z9Fg7FBT26uQ==",
-      "requires": {
-        "@sendgrid/client": "^7.4.2",
-        "@sendgrid/helpers": "^7.4.2"
-      }
-    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -22300,14 +22222,6 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
-    },
-    "axios": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
-      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
-      "requires": {
-        "follow-redirects": "^1.10.0"
-      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -24182,11 +24096,6 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
-    },
-    "deepmerge": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@emotion/styled": "^11.0.0",
         "@material-ui/core": "^4.11.0",
         "@material-ui/icons": "^4.9.1",
+        "@sendgrid/mail": "^7.4.2",
         "@testing-library/jest-dom": "^4.2.4",
         "@testing-library/react": "^9.5.0",
         "@testing-library/user-event": "^7.2.1",
@@ -2484,6 +2485,41 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.1.0.tgz",
       "integrity": "sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A=="
     },
+    "node_modules/@sendgrid/client": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.4.2.tgz",
+      "integrity": "sha512-bu8lLbRD+OV7YsYNemEy8DRoxs8/8u325EXNlQ3VaqhcpbM0eSvdL5e5Wa7VZpbczcNCJmf/sr/uqFmwcO5S+A==",
+      "dependencies": {
+        "@sendgrid/helpers": "^7.4.2",
+        "axios": "^0.21.1"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
+    "node_modules/@sendgrid/helpers": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.4.2.tgz",
+      "integrity": "sha512-b/IyBwT4zrOfXA0ISvWZsnhYz+5uAO20n68J8n/6qe5P1E2p0L7kWNTN5LYu0S7snJPUlbEa6FpfrSKzEcP9JA==",
+      "dependencies": {
+        "deepmerge": "^4.2.2"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/@sendgrid/mail": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.4.2.tgz",
+      "integrity": "sha512-hvIOnm8c3zVyDnJcyBuAeujmpKX56N3D/LpiZrFuLHjAz4iEHrmL2sJ3iU9O6hxcb07gd1CES+z9Fg7FBT26uQ==",
+      "dependencies": {
+        "@sendgrid/client": "^7.4.2",
+        "@sendgrid/helpers": "^7.4.2"
+      },
+      "engines": {
+        "node": "6.* || 8.* || >=10.*"
+      }
+    },
     "node_modules/@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -3924,6 +3960,14 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
     },
+    "node_modules/axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "dependencies": {
+        "follow-redirects": "^1.10.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.2.0.tgz",
@@ -4966,7 +5010,6 @@
       "dependencies": {
         "anymatch": "~3.1.1",
         "braces": "~3.0.2",
-        "fsevents": "~2.1.2",
         "glob-parent": "~5.1.0",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -6100,6 +6143,14 @@
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/default-gateway": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/default-gateway/-/default-gateway-4.2.0.tgz",
@@ -6774,8 +6825,7 @@
         "esprima": "^4.0.1",
         "estraverse": "^4.2.0",
         "esutils": "^2.0.2",
-        "optionator": "^0.8.1",
-        "source-map": "~0.6.1"
+        "optionator": "^0.8.1"
       },
       "bin": {
         "escodegen": "bin/escodegen.js",
@@ -8251,7 +8301,6 @@
       "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-3.2.2-rc.1.tgz",
       "integrity": "sha512-Q/b0f3mPmhZ3CZILCMaWKxZh+js3J0is4eF1IMyHrDcYvBENTlepfb0oE6VNLcw3pwxxtmvIP//N+4bWUzHI1w==",
       "dependencies": {
-        "@emotion/is-prop-valid": "^0.8.2",
         "framesync": "^5.0.0",
         "hey-listen": "^1.0.8",
         "popmotion": "^9.1.0",
@@ -10078,7 +10127,6 @@
         "@jest/types": "^24.9.0",
         "anymatch": "^2.0.0",
         "fb-watchman": "^2.0.0",
-        "fsevents": "^1.2.7",
         "graceful-fs": "^4.1.15",
         "invariant": "^2.2.4",
         "jest-serializer": "^24.9.0",
@@ -14332,7 +14380,10 @@
     "node_modules/react-icons": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.2.0.tgz",
-      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ=="
+      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
@@ -14438,7 +14489,6 @@
         "eslint-plugin-react-hooks": "^1.6.1",
         "file-loader": "4.3.0",
         "fs-extra": "^8.1.0",
-        "fsevents": "2.1.2",
         "html-webpack-plugin": "4.0.0-beta.11",
         "identity-obj-proxy": "3.0.0",
         "jest": "24.9.0",
@@ -17606,8 +17656,7 @@
       "dependencies": {
         "chokidar": "^3.4.1",
         "graceful-fs": "^4.1.2",
-        "neo-async": "^2.5.0",
-        "watchpack-chokidar2": "^2.0.0"
+        "neo-async": "^2.5.0"
       },
       "optionalDependencies": {
         "watchpack-chokidar2": "^2.0.0"
@@ -17892,7 +17941,6 @@
         "anymatch": "^2.0.0",
         "async-each": "^1.0.1",
         "braces": "^2.3.2",
-        "fsevents": "^1.2.7",
         "glob-parent": "^3.1.0",
         "inherits": "^2.0.3",
         "is-binary-path": "^1.0.0",
@@ -21008,6 +21056,32 @@
         }
       }
     },
+    "@sendgrid/client": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/client/-/client-7.4.2.tgz",
+      "integrity": "sha512-bu8lLbRD+OV7YsYNemEy8DRoxs8/8u325EXNlQ3VaqhcpbM0eSvdL5e5Wa7VZpbczcNCJmf/sr/uqFmwcO5S+A==",
+      "requires": {
+        "@sendgrid/helpers": "^7.4.2",
+        "axios": "^0.21.1"
+      }
+    },
+    "@sendgrid/helpers": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/helpers/-/helpers-7.4.2.tgz",
+      "integrity": "sha512-b/IyBwT4zrOfXA0ISvWZsnhYz+5uAO20n68J8n/6qe5P1E2p0L7kWNTN5LYu0S7snJPUlbEa6FpfrSKzEcP9JA==",
+      "requires": {
+        "deepmerge": "^4.2.2"
+      }
+    },
+    "@sendgrid/mail": {
+      "version": "7.4.2",
+      "resolved": "https://registry.npmjs.org/@sendgrid/mail/-/mail-7.4.2.tgz",
+      "integrity": "sha512-hvIOnm8c3zVyDnJcyBuAeujmpKX56N3D/LpiZrFuLHjAz4iEHrmL2sJ3iU9O6hxcb07gd1CES+z9Fg7FBT26uQ==",
+      "requires": {
+        "@sendgrid/client": "^7.4.2",
+        "@sendgrid/helpers": "^7.4.2"
+      }
+    },
     "@sheerun/mutationobserver-shim": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
@@ -22226,6 +22300,14 @@
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
       "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
+    },
+    "axios": {
+      "version": "0.21.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+      "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+      "requires": {
+        "follow-redirects": "^1.10.0"
+      }
     },
     "axobject-query": {
       "version": "2.2.0",
@@ -24100,6 +24182,11 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "default-gateway": {
       "version": "4.2.0",
@@ -30961,7 +31048,8 @@
     "react-icons": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.2.0.tgz",
-      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ=="
+      "integrity": "sha512-rmzEDFt+AVXRzD7zDE21gcxyBizD/3NqjbX6cmViAgdqfJ2UiLer8927/QhhrXQV7dEj/1EGuOTPp7JnLYVJKQ==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4371,7 +4371,8 @@
     "node_modules/babel-runtime/node_modules/core-js": {
       "version": "2.6.11",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
-      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg==",
+      "hasInstallScript": true
     },
     "node_modules/babel-runtime/node_modules/regenerator-runtime": {
       "version": "0.11.1",
@@ -5507,7 +5508,8 @@
     "node_modules/core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "hasInstallScript": true
     },
     "node_modules/core-js-compat": {
       "version": "3.6.5",
@@ -5529,7 +5531,8 @@
     "node_modules/core-js-pure": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA=="
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "hasInstallScript": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.2",
@@ -10096,6 +10099,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -17654,6 +17658,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -17905,6 +17910,7 @@
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "@emotion/styled": "^11.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
-    "@sendgrid/mail": "^7.4.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@emotion/styled": "^11.0.0",
     "@material-ui/core": "^4.11.0",
     "@material-ui/icons": "^4.9.1",
+    "@sendgrid/mail": "^7.4.2",
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.5.0",
     "@testing-library/user-event": "^7.2.1",

--- a/src/components/dashboard/DashboardNoTeam/ConfirmTeamCreation/ConfirmTeamCreation.js
+++ b/src/components/dashboard/DashboardNoTeam/ConfirmTeamCreation/ConfirmTeamCreation.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { useMutation, useApolloClient, gql } from '@apollo/client';
+import { useMutation, useApolloClient } from '@apollo/client';
 import { useDispatch } from 'react-redux';
-
 import { Box, Text, Heading, Button, Flex, HStack, VStack } from '@chakra-ui/react';
 
+import { ADD_USER_TO_TEAM, CREATE_TEAM, SEND_INVITE_EMAILS } from 'data/gql/team';
 import { currentUser } from 'data/actions/auth';
 
 const ConfirmTeamCreation = props => {
@@ -11,28 +11,9 @@ const ConfirmTeamCreation = props => {
   const dispatch = useDispatch();
   const client = useApolloClient();
 
-  const CREATE_TEAM = gql`
-    mutation createTeam($name: String!, $organization: String!) {
-      createTeam(name: $name, organization: $organization, amountRaised: 0, itemsSold: 0) {
-        id
-      }
-    }
-  `;
-
-  const ADD_USER_TO_TEAM = gql`
-    mutation updateUser($id: ID!, $teamId: String) {
-      updateUser(id: $id, teamId: $teamId) {
-        email
-        firstName
-        lastName
-        id
-        teamId
-      }
-    }
-  `;
-
   const [createTeam] = useMutation(CREATE_TEAM);
   const [addUser] = useMutation(ADD_USER_TO_TEAM);
+  const [inviteTeam] = useMutation(SEND_INVITE_EMAILS);
 
   const executeQuery = () => {
     createTeam({
@@ -40,9 +21,21 @@ const ConfirmTeamCreation = props => {
     })
       .then(data => {
         const teamId = data.data.createTeam.id;
+        const list = [...inputList];
         addUser({
           variables: { id: userId, teamId },
         }).then(dispatch(currentUser(client)));
+
+        inviteTeam({
+          variables: { emails: list, teamId: teamId },
+        })
+          .then(data => {
+            console.log(data);
+            // Create a toast or alert to indicate emails have been sent
+          })
+          .catch(e => {
+            console.log(e);
+          });
       })
       .catch(e => {
         console.log(e);

--- a/src/components/dashboard/DashboardNoTeam/ConfirmTeamCreation/ConfirmTeamCreation.js
+++ b/src/components/dashboard/DashboardNoTeam/ConfirmTeamCreation/ConfirmTeamCreation.js
@@ -13,7 +13,7 @@ const ConfirmTeamCreation = props => {
 
   const [createTeam] = useMutation(CREATE_TEAM);
   const [addUser] = useMutation(ADD_USER_TO_TEAM);
-  const [inviteTeam] = useMutation(SEND_INVITE_EMAILS);
+  const [inviteUsersToTeam] = useMutation(SEND_INVITE_EMAILS);
 
   const executeQuery = () => {
     createTeam({
@@ -26,7 +26,7 @@ const ConfirmTeamCreation = props => {
           variables: { id: userId, teamId },
         }).then(dispatch(currentUser(client)));
 
-        inviteTeam({
+        inviteUsersToTeam({
           variables: { emails: list, teamId: teamId },
         })
           .then(data => {

--- a/src/data/gql/team/index.js
+++ b/src/data/gql/team/index.js
@@ -1,0 +1,39 @@
+import { gql } from '@apollo/client';
+
+export const GET_TEAM_INFO = gql`
+  query getTeam($id: String!) {
+    getTeam(id: $id) {
+      name
+      organization
+      id
+      amountRaised
+      itemsSold
+    }
+  }
+`;
+
+export const SEND_INVITE_EMAILS = gql`
+  mutation inviteTeam($emails: [String!], $teamId: String!) {
+    inviteTeam(emails: $emails, teamId: $teamId)
+  }
+`;
+
+export const CREATE_TEAM = gql`
+  mutation createTeam($name: String!, $organization: String!) {
+    createTeam(name: $name, organization: $organization, amountRaised: 0, itemsSold: 0) {
+      id
+    }
+  }
+`;
+
+export const ADD_USER_TO_TEAM = gql`
+  mutation updateUser($id: ID!, $teamId: String) {
+    updateUser(id: $id, teamId: $teamId) {
+      email
+      firstName
+      lastName
+      id
+      teamId
+    }
+  }
+`;

--- a/src/data/gql/team/index.js
+++ b/src/data/gql/team/index.js
@@ -13,8 +13,8 @@ export const GET_TEAM_INFO = gql`
 `;
 
 export const SEND_INVITE_EMAILS = gql`
-  mutation inviteTeam($emails: [String!], $teamId: String!) {
-    inviteTeam(emails: $emails, teamId: $teamId)
+  mutation inviteUsersToTeam($emails: [String!], $teamId: String!) {
+    inviteUsersToTeam(emails: $emails, teamId: $teamId)
   }
 `;
 

--- a/src/pages/Storefront/Storefront.js
+++ b/src/pages/Storefront/Storefront.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { ChakraProvider } from '@chakra-ui/react';
 
-import { Navbar, BestSellers, ItemListings, Footer } from 'components/storefront';
+import { Navbar, BestSellers, ItemListings, Footer } from 'components/Storefront';
 import { useShopify } from 'hooks/useShopify';
 import storeTheme from 'themes/store';
 

--- a/src/pages/TeamView/TeamView.js
+++ b/src/pages/TeamView/TeamView.js
@@ -82,7 +82,7 @@ const InviteTeamMembers = () => {
     })
       .then(data => {
         console.log(data);
-        // Create a toast or something
+        // Create a toast or alert to indicate emails have been sent
       })
       .catch(e => {
         console.log(e);

--- a/src/pages/TeamView/TeamView.js
+++ b/src/pages/TeamView/TeamView.js
@@ -51,7 +51,7 @@ const InviteTeamMembers = () => {
     setInputList([...inputList, '']);
   };
 
-  const [inviteTeam] = useMutation(SEND_INVITE_EMAILS);
+  const [inviteUsersToTeam] = useMutation(SEND_INVITE_EMAILS);
   const {
     user: { teamId },
   } = useSelector(state => state.auth);
@@ -59,7 +59,7 @@ const InviteTeamMembers = () => {
   const handleSubmit = e => {
     e.preventDefault();
     const list = [...inputList];
-    inviteTeam({
+    inviteUsersToTeam({
       variables: { emails: list, teamId: teamId },
     })
       .then(data => {

--- a/src/pages/TeamView/TeamView.js
+++ b/src/pages/TeamView/TeamView.js
@@ -1,9 +1,9 @@
 import React, { useMemo, useState } from 'react';
-import { useMutation, useQuery, gql } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import { useSelector } from 'react-redux';
 import { Redirect } from 'react-router-dom';
-
 import { useTable, useSortBy } from 'react-table';
+import { GET_TEAM_INFO, SEND_INVITE_EMAILS } from '../../data/gql/team';
 import { TriangleDownIcon, TriangleUpIcon } from '@chakra-ui/icons';
 import {
   Box,
@@ -22,24 +22,6 @@ import {
   Td,
   chakra,
 } from '@chakra-ui/react';
-
-const GET_TEAM_INFO = gql`
-  query getTeam($id: String!) {
-    getTeam(id: $id) {
-      name
-      organization
-      id
-      amountRaised
-      itemsSold
-    }
-  }
-`;
-
-const SEND_INVITE_EMAILS = gql`
-  mutation inviteTeam($emails: [String!], $teamId: String!) {
-    inviteTeam(emails: $emails, teamId: $teamId)
-  }
-`;
 
 const TeamView = () => {
   const {

--- a/src/pages/TeamView/TeamView.js
+++ b/src/pages/TeamView/TeamView.js
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { useQuery, gql } from '@apollo/client';
+import { useMutation, useQuery, gql } from '@apollo/client';
 import { useSelector } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 
@@ -35,6 +35,12 @@ const GET_TEAM_INFO = gql`
   }
 `;
 
+const SEND_INVITE_EMAILS = gql`
+  mutation inviteTeam($emails: [String!], $teamId: String!) {
+    inviteTeam(emails: $emails, teamId: $teamId)
+  }
+`;
+
 const TeamView = () => {
   const {
     user: { teamId },
@@ -63,16 +69,24 @@ const InviteTeamMembers = () => {
     setInputList([...inputList, '']);
   };
 
+  const [inviteTeam] = useMutation(SEND_INVITE_EMAILS);
+  const {
+    user: { teamId },
+  } = useSelector(state => state.auth);
+
   const handleSubmit = e => {
     e.preventDefault();
-    //TODO: The below displays the inputted emails as an alert
-    //      Should change to actually handle the submit function
     const list = [...inputList];
-    let output = '';
-    for (let i = 0; i < list.length; i++) {
-      output = output.concat(list[i]);
-    }
-    alert(output);
+    inviteTeam({
+      variables: { emails: list, teamId: teamId },
+    })
+      .then(data => {
+        console.log(data);
+        // Create a toast or something
+      })
+      .catch(e => {
+        console.log(e);
+      });
   };
 
   return (


### PR DESCRIPTION
## Description

Link to ticket: https://www.notion.so/uwblueprintexecs/Email-Service-for-Inviting-Users-to-Team-78326acbe90345c59d15307c48efd4ed

See accompanying server PR: https://github.com/uwblueprint/building-up-server/pull/41

## Approach

NOTE: THIS PR IS THE FRONTEND CHANGES ASSOCIATED WITH THIS TICKET
- Integrated Twilio's SendGrid API for free (100 emails a day for free) to send general emails. All of the credentials are listed in the ticket as well.
- Added a mutation for retrieving email addresses from client.
- Also added `SENDGRID_API_KEY` to Heroku as config var.

## Testing

Existing user:
- Make sure you add the API key to `.env` for testing in building-up-server
- Pull the branch `sendgrid-service` on building-up-client
- Login to the UI, go to Teams, add your own email address and press send invites. If you add multiple, it should send emails to all of those email addresses.
- You should receive an email in your inbox from hongyichen@uwblueprint.org (temporary email address)

Create a new user:
- Same steps 1 and 2 as above.
- Create a new user, go through the Team creation flow and add emails.
- You should receive an email in your inbox from hongyichen@uwblueprint.org (temporary email address) once you press confirm.

