### PR TITLE
Move authentication spinner to only render for Dashboard routes

### DIFF
--- a/src/shared/App.js
+++ b/src/shared/App.js
@@ -32,28 +32,28 @@ function App() {
 
   return (
     <ChakraProvider theme={dashboardTheme}>
-      {authenticating ? (
-        <Flex direction="column" alignItems="center">
-          <div>Authenticating... </div>
-          <Spinner size="xl" />
-        </Flex>
-      ) : (
-        <Router>
-          <Switch>
-            <Route exact path="/login">
-              {user ? <Redirect to="/" /> : <LoginRegister />}
-            </Route>
-            <Route exact path="/chakraExpoDashboard">
-              <ChakraExpoDashboard />
-            </Route>
-            <Route exact path="/chakraExpoStore">
-              <ChakraProvider theme={storeTheme}>
-                <ChakraExpoStore />
-              </ChakraProvider>
-            </Route>
-            <Route exact path="/store">
-              <Storefront />
-            </Route>
+      <Router>
+        <Switch>
+          <Route exact path="/login">
+            {user ? <Redirect to="/" /> : <LoginRegister />}
+          </Route>
+          <Route exact path="/chakraExpoDashboard">
+            <ChakraExpoDashboard />
+          </Route>
+          <Route exact path="/chakraExpoStore">
+            <ChakraProvider theme={storeTheme}>
+              <ChakraExpoStore />
+            </ChakraProvider>
+          </Route>
+          <Route exact path="/store">
+            <Storefront />
+          </Route>
+          {authenticating ? (
+            <Flex direction="column" alignItems="center">
+              <div>Authenticating... </div>
+              <Spinner size="xl" />
+            </Flex>
+          ) : (
             <ProtectedRoute path="/">
               <Grid templateColumns={`${NAVBAR_WIDTH} 1fr`} h="100vh">
                 <Box borderRight="2px solid black" w="100%" h="100%">
@@ -80,9 +80,9 @@ function App() {
                 </Box>
               </Grid>
             </ProtectedRoute>
-          </Switch>
-        </Router>
-      )}
+          )}
+        </Switch>
+      </Router>
     </ChakraProvider>
   );
 


### PR DESCRIPTION
## Description

Link to ticket: https://www.notion.so/uwblueprintexecs/cc098375fd224e09b6efd05f453b1c5c?v=e4bd24ffa7aa470ba4a7f6b989eae603&p=e335d6f8b4b7496e9b3680d3f1f987c7

## Approach

- Moved authentication spinner rendering to wrap Dashboard routes

## Testing

- Visit dashboard routes and see that there is an authentication spinner
- Visit non-dashboard routes and see that there is no authentication spinner