### PR TITLE
Responsive Product Page

### DIFF
--- a/src/components/storefront/Home/AllItems/AllItems.js
+++ b/src/components/storefront/Home/AllItems/AllItems.js
@@ -18,8 +18,15 @@ const AllItems = () => {
           <ItemGridSkeleton />
         ) : (
           data &&
-          data.map(({ id, title, images, variants }) => (
-            <Item key={id} id={id} name={title} image={images && images[0].src} price={variants && variants[0].price} />
+          data.map(({ id, title, images, variants, availableForSale }) => (
+            <Item
+              key={id}
+              id={id}
+              name={title}
+              image={images && images[0].src}
+              price={variants && variants[0].price}
+              availableForSale={availableForSale}
+            />
           ))
         )}
       </ItemGrid>

--- a/src/components/storefront/Home/BestSellers/BestSellers.js
+++ b/src/components/storefront/Home/BestSellers/BestSellers.js
@@ -19,8 +19,15 @@ const BestSellers = () => {
           <ItemGridSkeleton />
         ) : (
           bestSellersCollection &&
-          bestSellersCollection.products.map(({ id, title, images, variants }) => (
-            <Item key={id} id={id} name={title} image={images && images[0].src} price={variants && variants[0].price} />
+          bestSellersCollection.products.map(({ id, title, images, variants, availableForSale }) => (
+            <Item
+              key={id}
+              id={id}
+              name={title}
+              image={images && images[0].src}
+              price={variants && variants[0].price}
+              availableForSale={availableForSale}
+            />
           ))
         )}
       </ItemGrid>

--- a/src/components/storefront/Home/Item/Item.js
+++ b/src/components/storefront/Home/Item/Item.js
@@ -1,18 +1,27 @@
 import * as React from 'react';
-import { AspectRatio, VStack, Heading, Image, Link } from '@chakra-ui/react';
+import { AspectRatio, Center, VStack, Heading, Image, Link } from '@chakra-ui/react';
 import { useRouteMatch } from 'react-router-dom';
 
 import PreserveQueryParamsLink from 'components/storefront/PreserveQueryParamsLink/PreserveQueryParamsLink';
 
-const Item = ({ id, name, image, price }) => {
+const OutOfStockMask = () => (
+  <Center position="absolute" top={0} w="100%" h="100%" bg="rgba(128,128,128,0.6)">
+    <Heading as="h4" size="h3" color="white">
+      Out of Stock
+    </Heading>
+  </Center>
+);
+
+const Item = ({ id, name, image, price, availableForSale }) => {
   const { path } = useRouteMatch();
 
   return (
     <VStack textAlign="center">
-      <Link w="100%" as={PreserveQueryParamsLink} to={`${path}/products/${id}`} bg="white">
+      <Link position="relative" w="100%" as={PreserveQueryParamsLink} to={`${path}/products/${id}`} bg="white">
         <AspectRatio maxW="400px" ratio={1}>
-          <Image border="1px solid black" w={80} h={80} src={image} alt={name} objectFit="cover" />
+          <Image border="1px solid black" src={image} alt={name} objectFit="cover" />
         </AspectRatio>
+        {!availableForSale && <OutOfStockMask />}
       </Link>
       <Heading as="h4" size="subtitle" textTransform="uppercase">
         {name}

--- a/src/components/storefront/ProductDetails/AdditionalContent.js
+++ b/src/components/storefront/ProductDetails/AdditionalContent.js
@@ -30,7 +30,7 @@ const Item = ({ title, panel }) => {
                 color: 'black',
               }}
             >
-              <Heading as="h4" size="subtitle" textTransform="uppercase">
+              <Heading as="h4" size="subtitle" textTransform="uppercase" textAlign="left">
                 {title}
               </Heading>
               <Spacer />

--- a/src/components/storefront/ProductDetails/ProductDetails.js
+++ b/src/components/storefront/ProductDetails/ProductDetails.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Heading, Flex, Image, Text, Button, useNumberInput } from '@chakra-ui/react';
+import { Heading, Flex, Image, Text, Button, Stack, VStack, useNumberInput } from '@chakra-ui/react';
 import AdditionalContent from './AdditionalContent';
 import QuantityPicker from './QuantityPicker';
 import { useShopify } from 'hooks/useShopify';
@@ -7,7 +7,7 @@ import { useHistory } from 'react-router';
 
 const ProductDetails = ({ product, checkout }) => {
   const { id: checkoutId } = checkout;
-  const { images, title, description, variants } = product;
+  const { images, title, description, variants, availableForSale } = product;
   const { id: variantId, sku: variantSku, price: variantPrice } = variants[0];
   const { addLineItems } = useShopify();
   const history = useHistory();
@@ -33,13 +33,13 @@ const ProductDetails = ({ product, checkout }) => {
   });
 
   return (
-    <Flex>
-      <Flex direction="column" w="100%" h="100%">
+    <Stack direction={{ base: 'column', sm: 'row' }} spacing={8}>
+      <VStack spacing={6} flex={1} h="100%">
         {images.map(({ id, src }) => (
-          <Image key={id} boxSize="100%" border="1px solid black" src={src} alt={title} mb={6} />
+          <Image key={id} boxSize="100%" border="1px solid black" src={src} alt={title} />
         ))}
-      </Flex>
-      <Flex direction="column" w="100%" pl={10}>
+      </VStack>
+      <Flex direction="column" flex={1}>
         <Heading as="h4" size="subtitle" textTransform="uppercase" color="brand.gray">
           {`Item #${variantSku}`}
         </Heading>
@@ -50,13 +50,26 @@ const ProductDetails = ({ product, checkout }) => {
           {`$${variantPrice}`}
         </Heading>
         <Text my={5}>{description}</Text>
-        <QuantityPicker {...quantityPickerProps} />
-        <Button textTransform="uppercase" mt={5} mb={10} onClick={handleAddToShoppingBag}>
-          {'Add to shopping bag'}
+        {availableForSale ? (
+          <QuantityPicker {...quantityPickerProps} />
+        ) : (
+          <Heading as="h3" size="h3" textTransform="uppercase">
+            Out of Stock
+          </Heading>
+        )}
+        <Button
+          textTransform="uppercase"
+          mt={5}
+          mb={10}
+          minW="auto"
+          onClick={handleAddToShoppingBag}
+          disabled={!availableForSale}
+        >
+          Add to shopping bag
         </Button>
         <AdditionalContent />
       </Flex>
-    </Flex>
+    </Stack>
   );
 };
 

--- a/src/pages/Storefront/PageNotFound.js
+++ b/src/pages/Storefront/PageNotFound.js
@@ -3,11 +3,11 @@ import { VStack, Heading, Button, Text } from '@chakra-ui/react';
 import PreserveQueryParamsLink from 'components/storefront/PreserveQueryParamsLink/PreserveQueryParamsLink';
 
 const PageNotFound = () => (
-  <VStack p={24}>
-    <Heading textAlign="center">Item not found</Heading>
+  <VStack p={24} textAlign="center">
+    <Heading>Item not found</Heading>
     <Text mb={8}>Oops! The product you are looking for could not be found.</Text>
     <Button size="sm" as={PreserveQueryParamsLink} textTransform="uppercase" to="/store">
-      {'Return Home'}
+      Return Home
     </Button>
   </VStack>
 );

--- a/src/pages/Storefront/Product.js
+++ b/src/pages/Storefront/Product.js
@@ -3,9 +3,9 @@ import { useParams } from 'react-router-dom';
 import { Box, HStack, Skeleton, SkeletonText } from '@chakra-ui/react';
 
 import { useShopify } from 'hooks/useShopify';
-import { ProductDetails } from '../../components/storefront';
-import { Container } from '@chakra-ui/react';
 import PageNotFound from './PageNotFound';
+import { ProductDetails } from 'components/storefront';
+import { PageContainer } from 'components/storefront/PageContainer/PageContainer';
 
 const ProductSkeleton = () => (
   <HStack flex="0.5" spacing={8} align="flex-start">
@@ -26,16 +26,16 @@ const Product = () => {
 
   const product = productsData.find(product => product.id === id);
 
-  return productsLoading || checkoutLoading ? (
-    <Container maxW="container.xl" display="flex" flexDirection="column" flex="1" py={20} px={24}>
-      <ProductSkeleton />
-    </Container>
-  ) : product ? (
-    <Container maxW="container.xl" display="flex" flexDirection="column" flex="1" py={20} px={24}>
-      <ProductDetails product={product} checkout={checkoutData} />
-    </Container>
-  ) : (
-    <PageNotFound />
+  return (
+    <PageContainer>
+      {productsLoading || checkoutLoading ? (
+        <ProductSkeleton />
+      ) : product ? (
+        <ProductDetails product={product} checkout={checkoutData} />
+      ) : (
+        <PageNotFound />
+      )}
+    </PageContainer>
   );
 };
 

--- a/src/themes/store/components/Button.js
+++ b/src/themes/store/components/Button.js
@@ -28,6 +28,9 @@ const Button = {
       bg: 'black',
       _hover: {
         bg: 'brand.darkgray',
+        _disabled: {
+          bg: 'black',
+        },
       },
       _active: {
         bg: 'brand.darkgray',
@@ -39,6 +42,9 @@ const Button = {
       _hover: {
         color: 'white',
         bg: 'brand.darkgray',
+        _disabled: {
+          bg: 'white',
+        },
       },
       _active: {
         color: 'white',


### PR DESCRIPTION
Responsive design for the product page by wrapping in `PageContainer` created in #60 
* Also add an "out of stock" state for the product page and a corresponding mask on the homepage. Uses the `availableForSale` property on a Shopify product

## Screenshots
On small screens, single column, images are on top, similar to https://raisingtheroof.org/product/black-cuffed-toque/
![image](https://user-images.githubusercontent.com/26701004/115156543-b76bf480-a052-11eb-83b8-4b62ca8fc7b2.png)

Out of stock product page:
![image](https://user-images.githubusercontent.com/26701004/115338038-12473e00-a170-11eb-82cf-5519138c7762.png)


Out of stock mask on home page:
![image](https://user-images.githubusercontent.com/26701004/115338017-08bdd600-a170-11eb-8e86-a8c822292b2c.png)
