### PR TITLE
Sign in page redirect state

### DIFF
--- a/src/components/dashboard/DashboardRouter/DashboardRouter.js
+++ b/src/components/dashboard/DashboardRouter/DashboardRouter.js
@@ -57,7 +57,7 @@ const DashboardRouter = () => {
           After signing in, redirect to the original path 
           */}
           <Route exact path="/login">
-            {user ? <Redirect to={location.state?.from?.pathname ?? '/'} /> : <LoginRegister />}
+            <LoginRegister />
           </Route>
           <Route exact path="/resetPassword/:token">
             <ResetPassword />
@@ -97,7 +97,7 @@ const DashboardRouter = () => {
                       )}
 
                       <Route path="/">
-                        <Redirect to="/home" />
+                        <Redirect to="/home" />;
                       </Route>
                     </Switch>
                   </PageContainer>

--- a/src/components/dashboard/DashboardRouter/DashboardRouter.js
+++ b/src/components/dashboard/DashboardRouter/DashboardRouter.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { useDispatch, useSelector } from 'react-redux';
-import { Switch, Route, Redirect, useLocation } from 'react-router-dom';
+import { Switch, Route, Redirect } from 'react-router-dom';
 
 import { Box, Center, ChakraProvider, Grid, Spinner } from '@chakra-ui/react';
 
@@ -27,8 +27,6 @@ const DashboardRouter = () => {
 
   const { authenticating, user, team } = useSelector(state => state.auth);
   const { loading: teamLoading, data: teamData } = team;
-
-  const location = useLocation();
 
   // Try to login the user on app init
   useEffect(() => {

--- a/src/components/dashboard/LoginRegister/RedirectContext.jsx
+++ b/src/components/dashboard/LoginRegister/RedirectContext.jsx
@@ -1,0 +1,62 @@
+import React from 'react';
+import { Box, CloseButton, Heading, Text, VStack } from '@chakra-ui/react';
+
+const RedirectContextContent = ({ subtitle, title, description, onCancel }) => {
+  return (
+    <Box position="relative" minW="35%" borderRadius="lg" borderWidth="1px" borderColor="white" bg="white" mb={5} p={4}>
+      {onCancel && <CloseButton position="absolute" right="8px" onClick={onCancel} />}
+      <VStack align="flex-start">
+        {subtitle && (
+          <Heading as="h4" size="subtitle" opacity="0.5">
+            {subtitle}
+          </Heading>
+        )}
+        {title && (
+          <Heading as="h3" size="h3">
+            {title}
+          </Heading>
+        )}
+        {description && <Text>{description}</Text>}
+      </VStack>
+    </Box>
+  );
+};
+
+const InviteContext = ({ data, error, onCancel }) => {
+  return error ? (
+    <RedirectContextContent
+      subtitle="You're invited to:"
+      title="Oops!"
+      description="The invite link you followed is invalid."
+      onCancel={onCancel}
+    />
+  ) : (
+    <RedirectContextContent
+      subtitle="You're invited to:"
+      title={`Team ${data.getTeam.name}${data.getTeam.organization ? `- ${data.getTeam.organization}` : ''}`}
+      description="Sign in or create an account to accept this invitation"
+      onCancel={onCancel}
+    />
+  );
+};
+
+const EmailVerificationContext = () => (
+  <RedirectContextContent subtitle="Email Verification" description="Please verify your email by logging in." />
+);
+
+/**
+ * Displays special context at the top of the login/register page if needed,
+ * for example if the user followed an invite link
+ */
+
+const RedirectContext = ({ fromPath, inviteTeamId, teamInfoData, teamInfoError, onCancel }) => {
+  return fromPath ? (
+    fromPath.startsWith('/verify') ? (
+      <EmailVerificationContext />
+    ) : inviteTeamId ? (
+      <InviteContext data={teamInfoData} error={teamInfoError} onCancel={onCancel} />
+    ) : null
+  ) : null;
+};
+
+export default RedirectContext;

--- a/src/hooks/use-invite.js
+++ b/src/hooks/use-invite.js
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useDispatch } from 'react-redux';
-import { useMutation, useLazyQuery } from '@apollo/client';
+import { useMutation, useQuery, useLazyQuery } from '@apollo/client';
 
 import { UPDATE_USERS_TEAM } from 'data/actions/type';
 import { GET_TEAM_INFO } from 'data/gql/team';
@@ -11,7 +11,34 @@ import { JOIN_TEAM } from 'data/gql/user';
  *
  * Updates the Redux store after joining a team
  */
-const useInvite = () => {
+export const useInvite = teamIdSlug => {
+  const dispatch = useDispatch();
+
+  // The mutation to join a team
+  const joinTeamMutation = useMutation(JOIN_TEAM);
+  const [, { data: joinTeamData }] = joinTeamMutation;
+
+  // The mutation to fetch a team's info
+  const getTeamInfoQuery = useQuery(GET_TEAM_INFO, { variables: { id: teamIdSlug } });
+  const { data: teamData } = getTeamInfoQuery;
+
+  // After joining team, update the Redux store
+  React.useEffect(() => {
+    if (joinTeamData) {
+      const { teamId } = joinTeamData.joinTeam;
+      dispatch({ type: UPDATE_USERS_TEAM, payload: teamId });
+    }
+  }, [joinTeamData, teamData, dispatch]);
+
+  return { joinTeamMutation, getTeamInfoQuery };
+};
+
+/**
+ * A hook for managing the state of the invite flow, uses `useLazyQuery`
+ *
+ * Updates the Redux store after joining a team
+ */
+export const useInviteLazy = () => {
   const dispatch = useDispatch();
 
   // The mutation to join a team
@@ -32,5 +59,3 @@ const useInvite = () => {
 
   return { joinTeamMutation, getTeamInfoQuery };
 };
-
-export default useInvite;

--- a/src/hooks/use-invite.js
+++ b/src/hooks/use-invite.js
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import { useDispatch } from 'react-redux';
+import { useMutation, useLazyQuery } from '@apollo/client';
+
+import { UPDATE_USERS_TEAM } from 'data/actions/type';
+import { GET_TEAM_INFO } from 'data/gql/team';
+import { JOIN_TEAM } from 'data/gql/user';
+
+/**
+ * A hook for managing the state of the invite flow
+ *
+ * Updates the Redux store after joining a team
+ */
+const useInvite = () => {
+  const dispatch = useDispatch();
+
+  // The mutation to join a team
+  const joinTeamMutation = useMutation(JOIN_TEAM);
+  const [, { data: joinTeamData }] = joinTeamMutation;
+
+  // The mutation to fetch a team's info
+  const getTeamInfoQuery = useLazyQuery(GET_TEAM_INFO);
+  const { data: teamData } = getTeamInfoQuery;
+
+  // After joining team, update the Redux store
+  React.useEffect(() => {
+    if (joinTeamData) {
+      const { teamId } = joinTeamData.joinTeam;
+      dispatch({ type: UPDATE_USERS_TEAM, payload: teamId });
+    }
+  }, [joinTeamData, teamData, dispatch]);
+
+  return { joinTeamMutation, getTeamInfoQuery };
+};
+
+export default useInvite;

--- a/src/pages/LoginRegister/LoginRegister.js
+++ b/src/pages/LoginRegister/LoginRegister.js
@@ -1,21 +1,23 @@
-import React, { useState } from 'react';
-import { Box, Flex, Button, Image } from '@chakra-ui/react';
+import * as React from 'react';
+import { Box, Flex, Button, Image, Spinner, Center, useToast } from '@chakra-ui/react';
+import { Redirect, useHistory, useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+
+import useInvite from 'hooks/use-invite';
 
 import LoginInput from 'components/dashboard/LoginRegister/LoginInput';
 import RegisterInput from 'components/dashboard/LoginRegister/RegisterInput';
 import ResetPassword from 'components/dashboard/LoginRegister/ResetPassword';
+import RedirectContext from 'components/dashboard/LoginRegister/RedirectContext';
+import Toast from 'components/dashboard/Toast/Toast';
 import logo from 'assets/images/logo-black.png';
 
 const TabButton = props => {
   return (
     <Button
       variant="unstyled"
-      _focus={{
-        outline: 'none',
-      }}
-      _hover={{
-        color: 'brand.50',
-      }}
+      _focus={{ outline: 'none' }}
+      _hover={{ color: 'brand.50' }}
       onClick={props.onClick}
       opacity={props.opacity}
     >
@@ -28,46 +30,159 @@ const TabUnderline = () => {
   return <Box bg="brand.50" h="5px" borderRadius="sm" />;
 };
 
-function LoginRegister() {
-  const [loginRegister, setLoginRegister] = useState('LOGIN');
+const JoinTeamByInviteAfterLogin = ({ user, inviteTeamId, joinTeamMutation }) => {
+  const [joinTeam, { data: joinTeamData, error: joinTeamError }] = joinTeamMutation;
+
+  React.useEffect(() => {
+    joinTeam({ variables: { id: user.userId, teamId: inviteTeamId } });
+  }, [inviteTeamId, joinTeam, user.userId]);
+
+  return joinTeamData || joinTeamError ? (
+    <Redirect to={'/'} />
+  ) : (
+    <Center h="100vh">
+      <Spinner size="xl" />
+    </Center>
+  );
+};
+
+function LoginRegisterContent({ inviteTeamId, fromPath, teamInfoRes, onCancel }) {
+  const [loginRegister, setLoginRegister] = React.useState('LOGIN');
+
+  const { loading: teamInfoLoading, data: teamInfoData, error: teamInfoError, called: teamInfoCalled } = teamInfoRes;
 
   return (
-    <Flex minHeight="100vh" h="100%" w="100vw" justify="center" bg="background.login">
-      <Box minW="35%" marginBottom="50px">
+    <Flex minHeight="100vh" h="100%" w="100vw" justify="center" bg="background.primary">
+      <Flex direction="column" minW="35%" marginBottom="50px">
         <Flex justify="center" marginTop="36px" marginBottom="36px">
           <Image src={logo} w="350px" />
         </Flex>
-        {loginRegister === 'RESET' ? (
-          <Box minW="35%" borderRadius="lg" borderWidth="1px" bg="white">
-            <ResetPassword setLoginRegister={setLoginRegister} />
-          </Box>
+        {(inviteTeamId && !teamInfoCalled) || teamInfoLoading ? (
+          <Center h="100%">
+            <Spinner size="xl" />
+          </Center>
         ) : (
-          <Box minW="35%" borderRadius="lg" borderWidth="1px" bg="white">
-            <Flex direction="row" justify="space-between" margin="20px 100px 24px 100px">
-              <Box>
-                <TabButton opacity={loginRegister === 'LOGIN' ? '1' : '0.5'} onClick={() => setLoginRegister('LOGIN')}>
-                  Sign In
-                </TabButton>
-                {loginRegister === 'LOGIN' && <TabUnderline />}
+          <>
+            <RedirectContext
+              fromPath={fromPath}
+              inviteTeamId={inviteTeamId}
+              teamInfoData={teamInfoData}
+              teamInfoError={teamInfoError}
+              onCancel={onCancel}
+            />
+            {loginRegister === 'RESET' ? (
+              <Box minW="35%" borderRadius="lg" borderWidth="1px" borderColor="white" bg="white">
+                <ResetPassword setLoginRegister={setLoginRegister} />
               </Box>
-              <Box>
-                <TabButton
-                  opacity={loginRegister === 'REGISTER' ? '1' : '0.5'}
-                  onClick={() => setLoginRegister('REGISTER')}
-                >
-                  Join
-                </TabButton>
-                {loginRegister === 'REGISTER' && <TabUnderline />}
+            ) : (
+              <Box minW="35%" borderRadius="lg" borderWidth="1px" borderColor="white" bg="white">
+                <Flex direction="row" justify="space-between" margin="20px 100px 24px 100px">
+                  <Box>
+                    <TabButton
+                      opacity={loginRegister === 'LOGIN' ? '1' : '0.5'}
+                      onClick={() => setLoginRegister('LOGIN')}
+                    >
+                      Sign In
+                    </TabButton>
+                    {loginRegister === 'LOGIN' && <TabUnderline />}
+                  </Box>
+                  <Box>
+                    <TabButton
+                      opacity={loginRegister === 'REGISTER' ? '1' : '0.5'}
+                      onClick={() => setLoginRegister('REGISTER')}
+                    >
+                      Join
+                    </TabButton>
+                    {loginRegister === 'REGISTER' && <TabUnderline />}
+                  </Box>
+                </Flex>
+                <Box margin="0px 48px 40px 48px">
+                  {loginRegister === 'LOGIN' ? <LoginInput setLoginRegister={setLoginRegister} /> : <RegisterInput />}
+                </Box>
               </Box>
-            </Flex>
-            <Box margin="0px 48px 40px 48px">
-              {loginRegister === 'LOGIN' ? <LoginInput setLoginRegister={setLoginRegister} /> : <RegisterInput />}
-            </Box>
-          </Box>
+            )}
+          </>
         )}
-      </Box>
+      </Flex>
     </Flex>
   );
 }
+
+/**
+ * After successfully signing in, redirects to the path the user was previously on
+ *
+ * Displays to the user if they followed an invite link /verify email link
+ * If the user followed an invite link, they will get join the team after
+ * signing in or signing up, even if their account isn't verified yet
+ */
+const LoginRegister = () => {
+  const { user } = useSelector(state => state.auth);
+  const location = useLocation();
+  const history = useHistory();
+  const toast = useToast();
+
+  const fromPath = location.state?.from?.pathname;
+
+  // Check if the user came from an invite link
+  const inviteTeamId = React.useMemo(
+    () => (fromPath && fromPath.startsWith('/invite') ? fromPath.split('/')[2] : undefined),
+    [fromPath],
+  );
+
+  // useInvite hook
+  const { joinTeamMutation, getTeamInfoQuery } = useInvite();
+  const [getTeamInfo, teamInfoRes] = getTeamInfoQuery;
+  const [, { data: joinTeamData, error: joinTeamError }] = joinTeamMutation;
+
+  // Fetch the team info from the invite code
+  React.useEffect(() => {
+    if (inviteTeamId) {
+      getTeamInfo({ variables: { id: inviteTeamId } });
+    }
+  }, [inviteTeamId, getTeamInfo]);
+
+  // Toast result of trying to join the team
+  React.useEffect(() => {
+    if (joinTeamData && teamInfoRes.data) {
+      const { name, organization } = teamInfoRes.data.getTeam;
+
+      toast({
+        position: 'top',
+        render: props => (
+          <Toast
+            {...props}
+            description={`Successfully joined team: ${name}${organization ? ' - ' : ''}${organization}`}
+            isClosable
+          />
+        ),
+      });
+    }
+
+    if (joinTeamError) {
+      toast({ position: 'top', title: 'Error joining team', status: 'error', isClosable: true });
+    }
+  }, [joinTeamData, joinTeamError, teamInfoRes.data, toast]);
+
+  // If user no longer wants to take the action of the context, reset `location.state.from`
+  const onCancelContext = () => history.replace({ ...location, state: { ...location.state, from: null } });
+
+  return user ? (
+    inviteTeamId && teamInfoRes.data ? (
+      // If the user followed an invite link, automatically join the team first
+      <JoinTeamByInviteAfterLogin user={user} inviteTeamId={inviteTeamId} joinTeamMutation={joinTeamMutation} />
+    ) : (
+      // If we go to this page while the user is already signed in (exists in Redux store), redirect to where the user navigated from
+      <Redirect to={location.state?.from?.pathname ?? '/'} />
+    )
+  ) : (
+    // User is not signed in, show the login/register page
+    <LoginRegisterContent
+      fromPath={fromPath}
+      inviteTeamId={inviteTeamId}
+      teamInfoRes={teamInfoRes}
+      onCancel={onCancelContext}
+    />
+  );
+};
 
 export default LoginRegister;

--- a/src/pages/LoginRegister/LoginRegister.js
+++ b/src/pages/LoginRegister/LoginRegister.js
@@ -3,7 +3,7 @@ import { Box, Flex, Button, Image, Spinner, Center, useToast } from '@chakra-ui/
 import { Redirect, useHistory, useLocation } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
-import useInvite from 'hooks/use-invite';
+import { useInviteLazy } from 'hooks/use-invite';
 
 import LoginInput from 'components/dashboard/LoginRegister/LoginInput';
 import RegisterInput from 'components/dashboard/LoginRegister/RegisterInput';
@@ -130,7 +130,7 @@ const LoginRegister = () => {
   );
 
   // useInvite hook
-  const { joinTeamMutation, getTeamInfoQuery } = useInvite();
+  const { joinTeamMutation, getTeamInfoQuery } = useInviteLazy();
   const [getTeamInfo, teamInfoRes] = getTeamInfoQuery;
   const [, { data: joinTeamData, error: joinTeamError }] = joinTeamMutation;
 

--- a/src/shared/App.js
+++ b/src/shared/App.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Switch, Route, BrowserRouter } from 'react-router-dom';
 import { ChakraProvider } from '@chakra-ui/react';
+import { __DEV__ } from '@chakra-ui/utils';
 
 import dashboardTheme from '../themes/dashboard';
 import storeTheme from '../themes/store';
@@ -15,17 +16,18 @@ function App() {
     <BrowserRouter>
       <Switch>
         {/* pages with Chakra components, helpful to reference when developing */}
-        <Route exact path="/chakraExpoDashboard">
-          <ChakraProvider theme={dashboardTheme}>
-            <ChakraExpoDashboard />
-          </ChakraProvider>
-        </Route>
-        <Route exact path="/chakraExpoStore">
-          <ChakraProvider theme={storeTheme}>
-            <ChakraExpoStore />
-          </ChakraProvider>
-        </Route>
-
+        {__DEV__ && [
+          <Route exact path="/chakraExpoDashboard" key="/chakraExpoDashboard">
+            <ChakraProvider theme={dashboardTheme}>
+              <ChakraExpoDashboard />
+            </ChakraProvider>
+          </Route>,
+          <Route exact path="/chakraExpoStore" key="/chakraExpoStore">
+            <ChakraProvider theme={storeTheme}>
+              <ChakraExpoStore />
+            </ChakraProvider>
+          </Route>,
+        ]}
         {/* All store pages are controlled by StorefrontRouter */}
         <Route path="/store">
           <StorefrontRouter />


### PR DESCRIPTION
## Description

[Link to ticket](https://www.notion.so/uwblueprintexecs/Building-Up-be1b30c321554bffba37a64c6cdc1ec6?p=335cf9f59c2d42f580a7133cb402124b)

## Approach

In `LoginRegister`, look at `location.state.from` to see if the user came from `/invite` or `/verify`

Additionally, if the user comes from an invite link, they now join the team automatically after signing in / signing up. This was discussed with product & designers in a weekly sync and we came to the conclusion this was the best approach.
* Abstracted a controller for the invite functionality into a hook
* If the user came from an invite link, block loading the login page until we fetch the team id of the invite 
* After signing in, if user came from a valid invite link, add them to the team before redirecting to the home page.

## Testing

* Valid invite link flow: GO to `<netlifypreview>/invite/XEWJRK`, see the new context on login page, sign in to get added to the team
* Invalid invite link flow: GO to `<netlifypreview>/invite/foo`, see the new context on login page, sign in and you get redirect to homepage as usual
* Go to `<netlifypreview>/verify/foo`, see the new context. If this is a valid verify email link, sign in and your email should be verified. Else, sign in and it will let you know it's invalid (or, if your account is verified already, it just lets you thru).

## Screenshots

![image](https://user-images.githubusercontent.com/26701004/115929211-68a8cb00-a455-11eb-907c-295925271a20.png)
![image](https://user-images.githubusercontent.com/26701004/115929231-72cac980-a455-11eb-9604-e5afff35b0cd.png)

