### PR TITLE
dashboard root route

### DIFF
--- a/src/components/dashboard/DashboardRouter/DashboardRouter.js
+++ b/src/components/dashboard/DashboardRouter/DashboardRouter.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { useDispatch, useSelector } from 'react-redux';
-import { Switch, Route, Redirect } from 'react-router-dom';
+import { Switch, Route, Redirect, useLocation, useRouteMatch } from 'react-router-dom';
 
 import { Box, Center, ChakraProvider, Grid, Spinner } from '@chakra-ui/react';
 
@@ -21,9 +21,14 @@ import PageContainer from '../PageContainer/PageContainer';
 import Navbar, { NAVBAR_WIDTH } from '../Navbar/Navbar';
 import ProtectedRoute from '../ProtectedRoute/ProtectedRoute';
 
+export const DASHBOARD_ROOT_PATH = '/dashboard';
+
 const DashboardRouter = () => {
   const dispatch = useDispatch();
   const client = useApolloClient();
+  const locaiton = useLocation();
+  console.log('locaiton:', locaiton);
+  console.log('locaiton:', locaiton.state, locaiton.state?.from);
 
   const { authenticating, user, team } = useSelector(state => state.auth);
   const { loading: teamLoading, data: teamData } = team;
@@ -54,13 +59,13 @@ const DashboardRouter = () => {
           It also sets location.state.from
           After signing in, redirect to the original path 
           */}
-          <Route exact path="/login">
+          <Route exact path={`${DASHBOARD_ROOT_PATH}/login`}>
             <LoginRegister />
           </Route>
-          <Route exact path="/resetPassword/:token">
+          <Route exact path={`${DASHBOARD_ROOT_PATH}/resetPassword/:token`}>
             <ResetPassword />
           </Route>
-          <ProtectedRoute disableEmailVerify path="/">
+          <ProtectedRoute disableEmailVerify path={`${DASHBOARD_ROOT_PATH}`}>
             <Grid templateColumns={`${NAVBAR_WIDTH} 1fr`} templateRows="100vh" h="100vh">
               <Box borderRight="2px solid black" w="100%" h="100%">
                 {/** Navbar width is set manually to keep the position fixed */}
@@ -73,31 +78,39 @@ const DashboardRouter = () => {
                   </Center>
                 ) : (
                   <PageContainer>
-                    <Switch>
-                      <ProtectedRoute exact path="/home">
-                        <Dashboard team={teamData} />
-                      </ProtectedRoute>
+                    <InnerRouter teamData={teamData} />
+                    {/* <Switch>
                       <ProtectedRoute disableEmailVerify exact path="/verify/:hash">
                         <EmailVerify />
                       </ProtectedRoute>
                       <ProtectedRoute exact path="/invite/:teamId">
                         <Invite />
                       </ProtectedRoute>
-                      {teamData && (
-                        <ProtectedRoute exact path="/leaderboard">
-                          <Leaderboard team={teamData} />
-                        </ProtectedRoute>
-                      )}
-                      {teamData && (
-                        <ProtectedRoute exact path="/team">
-                          <TeamOverview team={teamData} />
-                        </ProtectedRoute>
-                      )}
+                      <ProtectedRoute path={`${DASHBOARD_ROOT_PATH}`}>
+                        <Switch>
+                          <ProtectedRoute exact path={`${DASHBOARD_ROOT_PATH}/home`}>
+                            <Dashboard team={teamData} />
+                          </ProtectedRoute>
+                          {teamData && (
+                            <ProtectedRoute exact path={`${DASHBOARD_ROOT_PATH}/leaderboard`}>
+                              <Leaderboard team={teamData} />
+                            </ProtectedRoute>
+                          )}
+                          {teamData && (
+                            <ProtectedRoute exact path={`${DASHBOARD_ROOT_PATH}/team`}>
+                              <TeamOverview team={teamData} />
+                            </ProtectedRoute>
+                          )}
+                          <Route path="/">
+                            <Redirect to={`${DASHBOARD_ROOT_PATH}/home`} />
+                          </Route>
+                        </Switch>
+                      </ProtectedRoute>
 
                       <Route path="/">
-                        <Redirect to="/home" />;
+                        <Redirect to="/store" />
                       </Route>
-                    </Switch>
+                    </Switch> */}
                   </PageContainer>
                 )}
               </Box>
@@ -106,6 +119,45 @@ const DashboardRouter = () => {
         </Switch>
       )}
     </ChakraProvider>
+  );
+};
+
+export const InnerRouter = ({ teamData }) => {
+  const { path } = useRouteMatch();
+  return (
+    <Switch>
+      <ProtectedRoute disableEmailVerify exact path={`${path}/verify/:hash`}>
+        <EmailVerify />
+      </ProtectedRoute>
+      <ProtectedRoute exact path={`${path}/invite/:teamId`}>
+        <Invite />
+      </ProtectedRoute>
+      <ProtectedRoute path={`${path}`}>
+        <Switch>
+          <ProtectedRoute exact path={`${path}/home`}>
+            <Dashboard team={teamData} />
+          </ProtectedRoute>
+          {teamData && (
+            <ProtectedRoute exact path={`${path}/leaderboard`}>
+              <Leaderboard team={teamData} />
+            </ProtectedRoute>
+          )}
+          {teamData && (
+            <ProtectedRoute exact path={`${path}/team`}>
+              <TeamOverview team={teamData} />
+            </ProtectedRoute>
+          )}
+          {/* /dashboard/** that's doesn't match redirect to /dashboard/home */}
+          <Route path="/">
+            <Redirect to={`${path}/home`} />
+          </Route>
+        </Switch>
+      </ProtectedRoute>
+      {/* Root level redirect is to the storefront */}
+      {/* <Route path="/">
+        <Redirect to="/store" />
+      </Route> */}
+    </Switch>
   );
 };
 

--- a/src/components/dashboard/DashboardRouter/DashboardRouter.js
+++ b/src/components/dashboard/DashboardRouter/DashboardRouter.js
@@ -79,38 +79,6 @@ const DashboardRouter = () => {
                 ) : (
                   <PageContainer>
                     <InnerRouter teamData={teamData} />
-                    {/* <Switch>
-                      <ProtectedRoute disableEmailVerify exact path="/verify/:hash">
-                        <EmailVerify />
-                      </ProtectedRoute>
-                      <ProtectedRoute exact path="/invite/:teamId">
-                        <Invite />
-                      </ProtectedRoute>
-                      <ProtectedRoute path={`${DASHBOARD_ROOT_PATH}`}>
-                        <Switch>
-                          <ProtectedRoute exact path={`${DASHBOARD_ROOT_PATH}/home`}>
-                            <Dashboard team={teamData} />
-                          </ProtectedRoute>
-                          {teamData && (
-                            <ProtectedRoute exact path={`${DASHBOARD_ROOT_PATH}/leaderboard`}>
-                              <Leaderboard team={teamData} />
-                            </ProtectedRoute>
-                          )}
-                          {teamData && (
-                            <ProtectedRoute exact path={`${DASHBOARD_ROOT_PATH}/team`}>
-                              <TeamOverview team={teamData} />
-                            </ProtectedRoute>
-                          )}
-                          <Route path="/">
-                            <Redirect to={`${DASHBOARD_ROOT_PATH}/home`} />
-                          </Route>
-                        </Switch>
-                      </ProtectedRoute>
-
-                      <Route path="/">
-                        <Redirect to="/store" />
-                      </Route>
-                    </Switch> */}
                   </PageContainer>
                 )}
               </Box>
@@ -153,10 +121,6 @@ export const InnerRouter = ({ teamData }) => {
           </Route>
         </Switch>
       </ProtectedRoute>
-      {/* Root level redirect is to the storefront */}
-      {/* <Route path="/">
-        <Redirect to="/store" />
-      </Route> */}
     </Switch>
   );
 };

--- a/src/components/dashboard/DashboardRouter/DashboardRouter.js
+++ b/src/components/dashboard/DashboardRouter/DashboardRouter.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from 'react';
 import { useApolloClient } from '@apollo/client';
 import { useDispatch, useSelector } from 'react-redux';
-import { Switch, Route, Redirect, useLocation, useRouteMatch } from 'react-router-dom';
+import { Switch, Route, Redirect, useRouteMatch } from 'react-router-dom';
 
 import { Box, Center, ChakraProvider, Grid, Spinner } from '@chakra-ui/react';
 
@@ -26,9 +26,6 @@ export const DASHBOARD_ROOT_PATH = '/dashboard';
 const DashboardRouter = () => {
   const dispatch = useDispatch();
   const client = useApolloClient();
-  const locaiton = useLocation();
-  console.log('locaiton:', locaiton);
-  console.log('locaiton:', locaiton.state, locaiton.state?.from);
 
   const { authenticating, user, team } = useSelector(state => state.auth);
   const { loading: teamLoading, data: teamData } = team;

--- a/src/components/dashboard/LoginRegister/RedirectContext.jsx
+++ b/src/components/dashboard/LoginRegister/RedirectContext.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Box, CloseButton, Heading, Text, VStack } from '@chakra-ui/react';
+import { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
 
 const RedirectContextContent = ({ subtitle, title, description, onCancel }) => {
   return (
@@ -51,7 +52,7 @@ const EmailVerificationContext = () => (
 
 const RedirectContext = ({ fromPath, inviteTeamId, teamInfoData, teamInfoError, onCancel }) => {
   return fromPath ? (
-    fromPath.startsWith('/verify') ? (
+    fromPath.startsWith(`${DASHBOARD_ROOT_PATH}/verify`) ? (
       <EmailVerificationContext />
     ) : inviteTeamId ? (
       <InviteContext data={teamInfoData} error={teamInfoError} onCancel={onCancel} />

--- a/src/components/dashboard/Navbar/Navbar.js
+++ b/src/components/dashboard/Navbar/Navbar.js
@@ -9,6 +9,7 @@ import { NavLink } from 'react-router-dom';
 import Logo from 'assets/images/logoWhite.png';
 import { logout } from 'data/actions/auth';
 import ShareStorefrontButton from 'components/dashboard/ShareStorefrontButton/ShareStorefrontButton';
+import { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
 
 export const NAVBAR_WIDTH = '280px';
 
@@ -60,15 +61,15 @@ const Navbar = props => {
     >
       <VStack color="gray.400" spacing={10} align="flex-start">
         <Image src={Logo} alt="Raising The Roof Logo" w="100%" />
-        <NavItem to="/home" icon={IoHomeOutline}>
+        <NavItem to={`${DASHBOARD_ROOT_PATH}/home`} icon={IoHomeOutline}>
           Home
         </NavItem>
         {hasTeam ? (
           <>
-            <NavItem to="/leaderboard" icon={IoPodiumOutline}>
+            <NavItem to={`${DASHBOARD_ROOT_PATH}/leaderboard`} icon={IoPodiumOutline}>
               Leaderboard
             </NavItem>
-            <NavItem to="/team" icon={FiUsers}>
+            <NavItem to={`${DASHBOARD_ROOT_PATH}/team`} icon={FiUsers}>
               Team
             </NavItem>
           </>

--- a/src/components/dashboard/ProtectedRoute/ProtectedRoute.js
+++ b/src/components/dashboard/ProtectedRoute/ProtectedRoute.js
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { Redirect, Route } from 'react-router-dom';
 
 import EmailVerificationRequired from 'pages/EmailVerificationRequired/EmailVerificationRequired';
+import { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
 
 /**
  * A wrapper on <Route> that:
@@ -27,7 +28,7 @@ const ProtectedRoute = ({ children, disableEmailVerify, ...rest }) => {
         ) : (
           <Redirect
             to={{
-              pathname: '/login',
+              pathname: `${DASHBOARD_ROOT_PATH}/login`,
               state: { from: location },
             }}
           />

--- a/src/components/storefront/CartItem/CartItem.js
+++ b/src/components/storefront/CartItem/CartItem.js
@@ -58,7 +58,7 @@ const CartItem = ({ title, sku, image, price, quantity, lineItemId, checkoutId }
           />
         </Link>
         <VStack alignItems="flex-start" minW="100px" pl={6}>
-          <chakra.h4 textStyles="lightCaption" color="brand.gray">
+          <chakra.h4 textStyle="lightCaption" color="brand.gray">
             {`Item #${sku}`}
           </chakra.h4>
           <Heading as="h4" size="subtitle" textTransform="uppercase" color="brand.darkgray">

--- a/src/pages/EmailVerify/EmailVerify.js
+++ b/src/pages/EmailVerify/EmailVerify.js
@@ -5,6 +5,7 @@ import { useMutation } from '@apollo/client';
 import { useDispatch, useSelector } from 'react-redux';
 import { Box, Center, Heading, Spinner, Text, Flex, Image, Button } from '@chakra-ui/react';
 import { UPDATE_USER_VERIFICATION } from 'data/actions/type';
+import { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
 import logo from 'assets/images/logo-black.png';
 
 function EmailVerify() {
@@ -50,7 +51,7 @@ function EmailVerify() {
           ? 'Your email has been verified successfully.'
           : 'Please check your email for the correct verification link.'}
       </Text>
-      <Button size="lg" variant="black" my="46px" as={RouterLink} to="/home">
+      <Button size="lg" variant="black" my="46px" as={RouterLink} to={`${DASHBOARD_ROOT_PATH}/home`}>
         Return to Home
       </Button>
     </Box>

--- a/src/pages/Invite/Invite.js
+++ b/src/pages/Invite/Invite.js
@@ -5,6 +5,7 @@ import { Box, Button, ButtonGroup, Center, Heading, Spinner, Text, VStack, useTo
 
 import { useInvite } from 'hooks/use-invite';
 
+import { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
 import Toast from 'components/dashboard/Toast/Toast';
 
 const InviteLayout = props => (
@@ -64,7 +65,7 @@ function Invite() {
       <Spinner size="xl" />
     </Center>
   ) : shouldRedirect ? (
-    <Redirect to="/" />
+    <Redirect to={`${DASHBOARD_ROOT_PATH}`} />
   ) : (
     <InviteLayout>
       {teamError ? (
@@ -83,7 +84,7 @@ function Invite() {
             </Button>
             <Button
               as={RouterLink}
-              to="/"
+              to={`${DASHBOARD_ROOT_PATH}`}
               isLoading={joinTeamLoading}
               variant="outline"
               colorScheme="gray"

--- a/src/pages/LoginRegister/LoginRegister.js
+++ b/src/pages/LoginRegister/LoginRegister.js
@@ -12,6 +12,8 @@ import RedirectContext from 'components/dashboard/LoginRegister/RedirectContext'
 import Toast from 'components/dashboard/Toast/Toast';
 import logo from 'assets/images/logo-black.png';
 
+import { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
+
 const TabButton = props => {
   return (
     <Button
@@ -38,7 +40,7 @@ const JoinTeamByInviteAfterLogin = ({ user, inviteTeamId, joinTeamMutation }) =>
   }, [inviteTeamId, joinTeam, user.userId]);
 
   return joinTeamData || joinTeamError ? (
-    <Redirect to={'/'} />
+    <Redirect to={`${DASHBOARD_ROOT_PATH}`} />
   ) : (
     <Center h="100vh">
       <Spinner size="xl" />
@@ -125,7 +127,7 @@ const LoginRegister = () => {
 
   // Check if the user came from an invite link
   const inviteTeamId = React.useMemo(
-    () => (fromPath && fromPath.startsWith('/invite') ? fromPath.split('/')[2] : undefined),
+    () => (fromPath && fromPath.startsWith(`${DASHBOARD_ROOT_PATH}/invite`) ? fromPath.split('/')[3] : undefined),
     [fromPath],
   );
 
@@ -172,7 +174,7 @@ const LoginRegister = () => {
       <JoinTeamByInviteAfterLogin user={user} inviteTeamId={inviteTeamId} joinTeamMutation={joinTeamMutation} />
     ) : (
       // If we go to this page while the user is already signed in (exists in Redux store), redirect to where the user navigated from
-      <Redirect to={location.state?.from?.pathname ?? '/'} />
+      <Redirect to={location.state?.from?.pathname ?? `${DASHBOARD_ROOT_PATH}`} />
     )
   ) : (
     // User is not signed in, show the login/register page

--- a/src/pages/ResetPassword/ResetPassword.js
+++ b/src/pages/ResetPassword/ResetPassword.js
@@ -18,6 +18,7 @@ import {
 import logo from 'assets/images/logo-black.png';
 import { Link as RouterLink, useParams } from 'react-router-dom';
 import { RESET_PASSWORD_MUTATION } from '../../data/gql/user';
+import { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
 
 const InputPassword = props => {
   const { token } = useParams();
@@ -103,7 +104,7 @@ const ConfirmPage = () => {
         </Heading>
       </Box>
       <Text mb="40px">You've successfully updated your password!</Text>
-      <Button as={RouterLink} mb="50px" to="/login">
+      <Button as={RouterLink} mb="50px" to={`${DASHBOARD_ROOT_PATH}/login`}>
         Return to Login
       </Button>
     </Flex>

--- a/src/pages/Storefront/Cart.js
+++ b/src/pages/Storefront/Cart.js
@@ -120,7 +120,7 @@ const OrderSummary = ({ checkoutData }) => {
               {/* TO DO: Coupon discount to be implemented in next PR */}
             </Flex>
           )}
-          <chakra.h4 textStyles="lightCaption" fontStyle="italic">
+          <chakra.h4 textStyle="lightCaption" fontStyle="italic">
             Shipping & taxes calculated at checkout.
           </chakra.h4>
         </VStack>

--- a/src/shared/App.js
+++ b/src/shared/App.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Switch, Route, BrowserRouter } from 'react-router-dom';
+import { Switch, Route, Redirect, BrowserRouter } from 'react-router-dom';
 import { ChakraProvider } from '@chakra-ui/react';
 import { __DEV__ } from '@chakra-ui/utils';
 
@@ -9,7 +9,7 @@ import storeTheme from '../themes/store';
 import ChakraExpoDashboard from '../themes/dashboard/ChakraExpoDashboard';
 import ChakraExpoStore from '../themes/store/ChakraExpoStore';
 import StorefrontRouter from '../components/storefront/StorefrontRouter/StorefrontRouter';
-import DashboardRouter from 'components/dashboard/DashboardRouter/DashboardRouter';
+import DashboardRouter, { DASHBOARD_ROOT_PATH } from 'components/dashboard/DashboardRouter/DashboardRouter';
 
 function App() {
   return (
@@ -33,8 +33,11 @@ function App() {
           <StorefrontRouter />
         </Route>
         {/* All dashboard pages are controlled by DashboardRouter */}
-        <Route path="/">
+        <Route path={`${DASHBOARD_ROOT_PATH}`}>
           <DashboardRouter />
+        </Route>
+        <Route path="/">
+          <Redirect to="/store" />
         </Route>
       </Switch>
     </BrowserRouter>


### PR DESCRIPTION
## Description

Link to ticket: N/A

Root route for the dashboard is now `/dashboard`. The default redirect goes to store.

Depends on https://github.com/uwblueprint/building-up-server/pull/55

this one is gonna be a bit hard to review I think, requires a lot of user testing but it's a really good chance to use the app and see if u find any bugs
